### PR TITLE
feat: add some simple benchmarks vs rwlock

### DIFF
--- a/examples/fast_write_benchmark.rs
+++ b/examples/fast_write_benchmark.rs
@@ -1,0 +1,33 @@
+pub fn main() {
+    let (mut tx, rx) = genzero::new::<u32>(0);
+
+    let writer = std::thread::spawn(move || {
+        let mut count = 0;
+        let ten_millis = std::time::Duration::from_millis(10);
+        let messages = 1000;
+        let mut nanos = 0u128;
+        for _n in 0..messages {
+            count = count + 1;
+            let now = std::time::Instant::now();
+            tx.send(count);
+            nanos += now.elapsed().as_nanos();
+            std::thread::sleep(ten_millis);
+        }
+
+        eprintln!("Average send time in nanos: {}", (nanos/messages) as f32);
+    });
+
+    let _reader = std::thread::spawn(move || {
+        let hundred_millis = std::time::Duration::from_millis(100);
+        loop {
+            let v = rx.recv();
+            if v == None {
+                break;
+            }
+
+            std::thread::sleep(hundred_millis);
+        }
+    });
+
+    writer.join().expect("writer didn't close cleanly");
+}

--- a/examples/fast_write_benchmark_rwlock.rs
+++ b/examples/fast_write_benchmark_rwlock.rs
@@ -1,0 +1,36 @@
+pub fn main() {
+    let lock = std::sync::Arc::new(std::sync::RwLock::new(0));
+
+    let reader_lock = lock.clone();
+
+    let writer = std::thread::spawn(move || {
+        let mut count = 0;
+        let ten_millis = std::time::Duration::from_millis(10);
+        let messages = 1000;
+        let mut nanos = 0u128;
+        for _n in 0..messages {
+            count = count + 1;
+            let now = std::time::Instant::now();
+            let mut v = lock.write().unwrap();
+            *v = count;
+            nanos += now.elapsed().as_nanos();
+            std::thread::sleep(ten_millis);
+        }
+
+        eprintln!("Average send time in nanos: {}", (nanos/messages) as f32);
+    });
+
+    let _reader = std::thread::spawn(move || {
+        let hundred_millis = std::time::Duration::from_millis(100);
+        loop {
+            let v = reader_lock.read().unwrap();
+            if *v == 1000 {
+                break;
+            }
+
+            std::thread::sleep(hundred_millis);
+        }
+    });
+
+    writer.join().expect("writer didn't close cleanly");
+}

--- a/flake.lock
+++ b/flake.lock
@@ -38,11 +38,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1718530797,
-        "narHash": "sha256-pup6cYwtgvzDpvpSCFh1TEUjw2zkNpk8iolbKnyFmmU=",
+        "lastModified": 1726937504,
+        "narHash": "sha256-bvGoiQBvponpZh8ClUcmJ6QnsNKw0EMrCQJARK3bI1c=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "b60ebf54c15553b393d144357375ea956f89e9a9",
+        "rev": "9357f4f23713673f310988025d9dc261c20e70c6",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -19,7 +19,6 @@
       {
         devShells.default = mkShell {
           nativeBuildInputs = [
-            pkgs.valgrind
             pkgs.cargo-nextest
             rust-bin.nightly.latest.default
           ];


### PR DESCRIPTION
I built a simple SPSC benchmark where the writer writes faster than the reader reads. The goal is to show how we get better throughput on the writer. 

The benchmark sends 1000 messages at 100Hz and the reader reads at 10Hz. One version uses genzero and the other uses an RwLock. Below is a plot showing average write time from 10 runs of the benchmark program (total of 10000 messages sent). We can see how we get consistently better throughput with genzero due to no lock contention. (NOTE: these benchmarks were both run on the same M2 Macbook air using a release build of both benchmarks)
![genzero_vs_rwlock_fast_write_spsc_benchmark](https://github.com/user-attachments/assets/a03fca7a-7078-4fb5-ac34-e65be322286d)
